### PR TITLE
fix: handle corrupted/empty jobs.dat file gracefully

### DIFF
--- a/FFMPEGAudioEncoder.py
+++ b/FFMPEGAudioEncoder.py
@@ -12795,7 +12795,7 @@ def open_jobs_manager():  # Opens the job manager window -----------------------
         try:
             with open("Runtime/jobs.dat", "rb") as pickle_file:
                 saved_jobs = pickle.load(pickle_file)
-        except FileNotFoundError:
+        except (FileNotFoundError, EOFError, pickle.UnpicklingError):
             return
 
         for (
@@ -12820,7 +12820,7 @@ def open_jobs_manager():  # Opens the job manager window -----------------------
                         saved_jobs
                     ):  # Update listbox window with list of saved jobs in dat file
                         job_listbox.insert(END, jobs)
-            except EOFError:
+            except (EOFError, pickle.UnpicklingError):
                 pass
             job_listbox.after(
                 100, updater


### PR DESCRIPTION
## Summary
- Fixed exception handling when loading jobs.dat to catch EOFError and pickle.UnpicklingError in addition to FileNotFoundError
- This prevents crashes when the jobs.dat file becomes corrupted or empty during long batch encodes

## Problem
During long batch encodes, the jobs.dat file that is generated/updated could sometimes throw an error when it was empty or corrupted. The initial load function only caught FileNotFoundError, so EOFError or pickle.UnpicklingError would crash the application.

## Solution
Updated both locations where jobs.dat is read:
1. `update_listbox_with_saved_jobs()`: Now catches FileNotFoundError, EOFError, and pickle.UnpicklingError
2. `updater()`: Now catches EOFError and pickle.UnpicklingError (FileNotFoundError is not needed here as it's inside the try block after initial checks)

## Testing
The fix gracefully handles:
- Missing jobs.dat file
- Empty jobs.dat file (0 bytes)
- Corrupted jobs.dat file (invalid pickle data)

## Related
This addresses the bug mentioned in release notes where jobs.dat errors occurred during long batch encodes.